### PR TITLE
feat: exit the process if it takes too long for a tx to be included in a block

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,18 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="dbbec896-4ab9-4a9a-ae52-42d52bfdf4e1" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/.idea/goomy-blob.iml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/vcs.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/scenarios/largetx/abis/looper.abi.json" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/scenarios/largetx/abis/looper.go" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/scenarios/largetx/largetx.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/cmd/blob-spammer/main.go" beforeDir="false" afterPath="$PROJECT_DIR$/cmd/blob-spammer/main.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/go.mod" beforeDir="false" afterPath="$PROJECT_DIR$/go.mod" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/go.sum" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/scenarios/scenarios.go" beforeDir="false" afterPath="$PROJECT_DIR$/scenarios/scenarios.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/txbuilder/client.go" beforeDir="false" afterPath="$PROJECT_DIR$/txbuilder/client.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/txbuilder/wallet.go" beforeDir="false" afterPath="$PROJECT_DIR$/txbuilder/wallet.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scenarios/largetx/largetx.go" beforeDir="false" afterPath="$PROJECT_DIR$/scenarios/largetx/largetx.go" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -45,24 +35,24 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "DefaultGoTemplateProperty": "Go File",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.go.formatter.settings.were.checked": "true",
-    "RunOnceActivity.go.migrated.go.modules.settings": "true",
-    "RunOnceActivity.go.modules.automatic.dependencies.download": "true",
-    "RunOnceActivity.go.modules.go.list.on.any.changes.was.set": "true",
-    "git-widget-placeholder": "Rebasing bharath/large-tx",
-    "go.import.settings.migrated": "true",
-    "go.sdk.automatically.set": "true",
-    "last_opened_file_path": "/Users/vedabharath/learn/goomy-blob",
-    "node.js.detected.package.eslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;DefaultGoTemplateProperty&quot;: &quot;Go File&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.go.formatter.settings.were.checked&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.go.migrated.go.modules.settings&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.go.modules.automatic.dependencies.download&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.go.modules.go.list.on.any.changes.was.set&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;bharath/timeout-for-txs&quot;,
+    &quot;go.import.settings.migrated&quot;: &quot;true&quot;,
+    &quot;go.sdk.automatically.set&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/vedabharath/learn/goomy-blob&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;
   }
-}]]></component>
+}</component>
   <component name="SharedIndexes">
     <attachedChunks>
       <set>

--- a/scenarios/eoatx/eoatx.go
+++ b/scenarios/eoatx/eoatx.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
+	"os"
 	"sync"
 	"time"
 
@@ -24,7 +25,7 @@ type ScenarioOptions struct {
 	Throughput   uint64
 	MaxPending   uint64
 	MaxWallets   uint64
-	Rebroadcast  uint64
+	Timeout      uint64
 	BaseFee      uint64
 	TipFee       uint64
 	Amount       uint64
@@ -53,7 +54,7 @@ func (s *Scenario) Flags(flags *pflag.FlagSet) error {
 	flags.Uint64VarP(&s.options.Throughput, "throughput", "t", 0, "Number of transfer transactions to send per slot")
 	flags.Uint64Var(&s.options.MaxPending, "max-pending", 0, "Maximum number of pending transactions")
 	flags.Uint64Var(&s.options.MaxWallets, "max-wallets", 0, "Maximum number of child wallets to use")
-	flags.Uint64Var(&s.options.Rebroadcast, "rebroadcast", 120, "Number of seconds to wait before re-broadcasting a transaction")
+	flags.Uint64Var(&s.options.Timeout, "timeout", 120, "Number of seconds to wait before timing out the test")
 	flags.Uint64Var(&s.options.BaseFee, "basefee", 20, "Max fee per gas to use in transfer transactions (in gwei)")
 	flags.Uint64Var(&s.options.TipFee, "tipfee", 2, "Max tip per gas to use in transfer transactions (in gwei)")
 	flags.Uint64Var(&s.options.Amount, "amount", 20, "Transfer amount per transaction (in gwei)")
@@ -239,8 +240,8 @@ func (s *Scenario) awaitTx(txIdx uint64, tx *types.Transaction, client *txbuilde
 		}
 		s.pendingWGroup.Done()
 	}()
-	if s.options.Rebroadcast > 0 {
-		go s.delayedResend(txIdx, tx, &awaitConfirmation)
+	if s.options.Timeout > 0 {
+		go s.timeTicker(txIdx, tx, &awaitConfirmation)
 	}
 
 	receipt, blockNum, err := client.AwaitTransaction(tx)
@@ -268,16 +269,15 @@ func (s *Scenario) awaitTx(txIdx uint64, tx *types.Transaction, client *txbuilde
 	s.logger.WithField("client", client.GetName()).Infof(" transaction %d confirmed in block #%v. total fee: %v gwei (base: %v, blob: %v)", txIdx+1, blockNum, gweiTotalFee, gweiBaseFee, gweiBlobFee)
 }
 
-func (s *Scenario) delayedResend(txIdx uint64, tx *types.Transaction, awaitConfirmation *bool) {
+func (s *Scenario) timeTicker(txIdx uint64, tx *types.Transaction, awaitConfirmation *bool) {
 	for {
-		time.Sleep(time.Duration(s.options.Rebroadcast) * time.Second)
+		time.Sleep(time.Duration(s.options.Timeout) * time.Second)
 
 		if !*awaitConfirmation {
 			break
 		}
 
-		client := s.tester.GetClient(tester.SelectRandom, 0)
-		client.SendTransaction(tx)
-		s.logger.WithField("client", client.GetName()).Infof(" transaction %d re-broadcasted.", txIdx+1)
+		s.logger.Infof("timeout reached for tx: %d with hash: %s, stopping test", txIdx, tx.Hash().String())
+		os.Exit(1)
 	}
 }

--- a/scenarios/erctx/erctx.go
+++ b/scenarios/erctx/erctx.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
+	"os"
 	"sync"
 	"time"
 
@@ -25,7 +26,7 @@ type ScenarioOptions struct {
 	Throughput   uint64
 	MaxPending   uint64
 	MaxWallets   uint64
-	Rebroadcast  uint64
+	Timeout      uint64
 	BaseFee      uint64
 	TipFee       uint64
 	Amount       uint64
@@ -56,7 +57,7 @@ func (s *Scenario) Flags(flags *pflag.FlagSet) error {
 	flags.Uint64VarP(&s.options.Throughput, "throughput", "t", 0, "Number of transfer transactions to send per slot")
 	flags.Uint64Var(&s.options.MaxPending, "max-pending", 0, "Maximum number of pending transactions")
 	flags.Uint64Var(&s.options.MaxWallets, "max-wallets", 0, "Maximum number of child wallets to use")
-	flags.Uint64Var(&s.options.Rebroadcast, "rebroadcast", 120, "Number of seconds to wait before re-broadcasting a transaction")
+	flags.Uint64Var(&s.options.Timeout, "timeout", 120, "Number of seconds to wait timing out the test")
 	flags.Uint64Var(&s.options.BaseFee, "basefee", 20, "Max fee per gas to use in transfer transactions (in gwei)")
 	flags.Uint64Var(&s.options.TipFee, "tipfee", 2, "Max tip per gas to use in transfer transactions (in gwei)")
 	flags.Uint64Var(&s.options.Amount, "amount", 20, "Transfer amount per transaction (in gwei)")
@@ -319,8 +320,8 @@ func (s *Scenario) awaitTx(txIdx uint64, tx *types.Transaction, client *txbuilde
 		}
 		s.pendingWGroup.Done()
 	}()
-	if s.options.Rebroadcast > 0 {
-		go s.delayedResend(txIdx, tx, &awaitConfirmation)
+	if s.options.Timeout > 0 {
+		go s.timeTicker(txIdx, tx, &awaitConfirmation)
 	}
 
 	receipt, blockNum, err := client.AwaitTransaction(tx)
@@ -348,16 +349,15 @@ func (s *Scenario) awaitTx(txIdx uint64, tx *types.Transaction, client *txbuilde
 	s.logger.WithField("client", client.GetName()).Infof(" transaction %d confirmed in block #%v. total fee: %v gwei (base: %v, blob: %v)", txIdx+1, blockNum, gweiTotalFee, gweiBaseFee, gweiBlobFee)
 }
 
-func (s *Scenario) delayedResend(txIdx uint64, tx *types.Transaction, awaitConfirmation *bool) {
+func (s *Scenario) timeTicker(txIdx uint64, tx *types.Transaction, awaitConfirmation *bool) {
 	for {
-		time.Sleep(time.Duration(s.options.Rebroadcast) * time.Second)
+		time.Sleep(time.Duration(s.options.Timeout) * time.Second)
 
 		if !*awaitConfirmation {
 			break
 		}
 
-		client := s.tester.GetClient(tester.SelectRandom, 0)
-		client.SendTransaction(tx)
-		s.logger.WithField("client", client.GetName()).Infof(" transaction %d re-broadcasted.", txIdx+1)
+		s.logger.Infof("timeout reached for tx: %d with hash: %s, stopping test", txIdx, tx.Hash().String())
+		os.Exit(1)
 	}
 }

--- a/scenarios/largetx/largetx.go
+++ b/scenarios/largetx/largetx.go
@@ -7,6 +7,7 @@ import (
 	largetx "github.com/ethpandaops/goomy-blob/scenarios/largetx/abis"
 	"github.com/ethpandaops/goomy-blob/utils"
 	"math/big"
+	"os"
 	"sync"
 	"time"
 
@@ -23,14 +24,14 @@ import (
 var LOOPER_CONTRACT_BYTECODE = "0x608060405234801561001057600080fd5b506101c5806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80638f491c6514610030575b600080fd5b61004361003e3660046100ee565b610059565b604051610050919061011f565b60405180910390f35b606060008267ffffffffffffffff1667ffffffffffffffff81111561008057610080610163565b6040519080825280602002602001820160405280156100a9578160200160208202803683370190505b50905060005b8367ffffffffffffffff168110156100e757808282815181106100d4576100d4610179565b60209081029190910101526001016100af565b5092915050565b60006020828403121561010057600080fd5b813567ffffffffffffffff8116811461011857600080fd5b9392505050565b6020808252825182820181905260009190848201906040850190845b818110156101575783518352928401929184019160010161013b565b50909695505050505050565b634e487b7160e01b600052604160045260246000fd5b634e487b7160e01b600052603260045260246000fdfea2646970667358221220b226884699e16cc47ae01a4cc201e790347695464df17edde46bbab26872400364736f6c63430008180033"
 
 type ScenarioOptions struct {
-	TotalCount  uint64
-	Throughput  uint64
-	MaxPending  uint64
-	MaxWallets  uint64
-	Rebroadcast uint64
-	BaseFee     uint64
-	TipFee      uint64
-	LoopCount   uint64
+	TotalCount uint64
+	Throughput uint64
+	MaxPending uint64
+	MaxWallets uint64
+	Timeout    uint64
+	BaseFee    uint64
+	TipFee     uint64
+	LoopCount  uint64
 }
 
 type Scenario struct {
@@ -57,7 +58,7 @@ func (s *Scenario) Flags(flags *pflag.FlagSet) error {
 	flags.Uint64VarP(&s.options.Throughput, "throughput", "t", 0, "Number of large transactions to send per slot")
 	flags.Uint64Var(&s.options.MaxPending, "max-pending", 0, "Maximum number of pending transactions")
 	flags.Uint64Var(&s.options.MaxWallets, "max-wallets", 0, "Maximum number of child wallets to use")
-	flags.Uint64Var(&s.options.Rebroadcast, "rebroadcast", 120, "Number of seconds to wait before re-broadcasting a transaction")
+	flags.Uint64Var(&s.options.Timeout, "timeout", 120, "Number of seconds to wait timing out the test")
 	flags.Uint64Var(&s.options.BaseFee, "basefee", 20, "Max fee per gas to use in large transactions (in gwei)")
 	flags.Uint64Var(&s.options.TipFee, "tipfee", 2, "Max tip per gas to use in large transactions (in gwei)")
 	flags.Uint64Var(&s.options.LoopCount, "loop-count", 20000, "The number of loops to perform in the contract. This will increase the gas units")
@@ -317,8 +318,8 @@ func (s *Scenario) awaitTx(txIdx uint64, tx *types.Transaction, client *txbuilde
 		}
 		s.pendingWGroup.Done()
 	}()
-	if s.options.Rebroadcast > 0 {
-		go s.delayedResend(txIdx, tx, &awaitConfirmation)
+	if s.options.Timeout > 0 {
+		go s.timeTicker(txIdx, tx, &awaitConfirmation)
 	}
 
 	receipt, blockNum, err := client.AwaitTransaction(tx)
@@ -346,16 +347,15 @@ func (s *Scenario) awaitTx(txIdx uint64, tx *types.Transaction, client *txbuilde
 	s.logger.WithField("client", client.GetName()).Infof(" transaction %d confirmed in block #%v. total gas units: %d, total fee: %v gwei (base: %v, blob: %v)", txIdx+1, blockNum, receipt.GasUsed, gweiTotalFee, gweiBaseFee, gweiBlobFee)
 }
 
-func (s *Scenario) delayedResend(txIdx uint64, tx *types.Transaction, awaitConfirmation *bool) {
+func (s *Scenario) timeTicker(txIdx uint64, tx *types.Transaction, awaitConfirmation *bool) {
 	for {
-		time.Sleep(time.Duration(s.options.Rebroadcast) * time.Second)
+		time.Sleep(time.Duration(s.options.Timeout) * time.Second)
 
 		if !*awaitConfirmation {
 			break
 		}
 
-		client := s.tester.GetClient(tester.SelectRandom, 0)
-		client.SendTransaction(tx)
-		s.logger.WithField("client", client.GetName()).Infof(" transaction %d re-broadcasted.", txIdx+1)
+		s.logger.Infof("timeout reached for tx: %d with hash: %s, stopping test", txIdx, tx.Hash().String())
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Currently, goomy-blobs tries infinite number of times to re-broadcast a tx which has not been included in a block yet. To run goomy-blobs as a test, we add a timeout param to timeout if a tx has not been included in a block for too long.