### PR TITLE
fix: set transactors noSend to true in large tx scenario

### DIFF
--- a/scenarios/largetx/largetx.go
+++ b/scenarios/largetx/largetx.go
@@ -97,8 +97,8 @@ func (s *Scenario) Init(testerCfg *tester.TesterConfig) error {
 }
 
 func (s *Scenario) Setup(testerCfg *tester.Tester) error {
-	s.logger.Infof("setting up scenario: largetx")
 	s.tester = testerCfg
+	s.logger.Infof("setting up scenario: largetx")
 	s.logger.Infof("deploying looper contract...")
 	receipt, _, err := s.DeployLooperContract()
 	if err != nil {
@@ -183,7 +183,7 @@ func (s *Scenario) DeployLooperContract() (*types.Receipt, *txbuilder.Client, er
 	wallet := s.tester.GetRootWallet()
 	client := s.tester.GetClient(tester.SelectByIndex, 0)
 
-	transactor, err := s.GetTransactor(wallet, false, big.NewInt(0))
+	transactor, err := s.GetTransactor(wallet, true, big.NewInt(0))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -191,10 +191,9 @@ func (s *Scenario) DeployLooperContract() (*types.Receipt, *txbuilder.Client, er
 	_, deployTx, _, err := largetx.DeployLooper(transactor, client.GetEthClient())
 	if err != nil {
 		return nil, nil, err
-
 	}
 
-	receipt, _, err := s.SendAndAwaitTx(wallet, deployTx, SendTxOpts{Gas: 3000000})
+	receipt, _, err := s.SendAndAwaitTx(wallet, deployTx, SendTxOpts{Gas: 2000000})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/scenarios/largetx/largetx.go
+++ b/scenarios/largetx/largetx.go
@@ -235,7 +235,7 @@ func (s *Scenario) sendTx(txIdx uint64) (*types.Transaction, *txbuilder.Client, 
 		return nil, nil, err
 	}
 
-	transactor, err := s.GetTransactor(wallet, false, big.NewInt(0))
+	transactor, err := s.GetTransactor(wallet, true, big.NewInt(0))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/txbuilder/client.go
+++ b/txbuilder/client.go
@@ -220,6 +220,7 @@ func (client *Client) AwaitTransaction(tx *types.Transaction) (*types.Receipt, u
 		client.logger.Warnf("receipt error: %v\n", err)
 		return nil, blockHeight, err
 	}
+
 	return nil, blockHeight, nil
 }
 


### PR DESCRIPTION
The transactors used to craft the looper contracts deploy tx and loop txs was sending the tx too, causing the tx to be sent twice which is undesirable. This was causing issues with deploying the looper contracts. Set the `NoSend` field to true fixes this.