### PR TITLE
send univ3swaptxs only via the root wallet

### DIFF
--- a/cmd/spamooor/main.go
+++ b/cmd/spamooor/main.go
@@ -105,8 +105,8 @@ func main() {
 		RpcHosts:      rpcHosts,
 		WalletPrivkey: cliArgs.privkey,
 		WalletCount:   100,
-		WalletPrefund: utils.EtherToWei(uint256.NewInt(3)),
-		WalletMinfund: utils.EtherToWei(uint256.NewInt(3)),
+		WalletPrefund: utils.WeiToEther(uint256.NewInt(10000000000000000)),
+		WalletMinfund: utils.WeiToEther(uint256.NewInt(10000000000000000)),
 		Scenario:      scenarioName,
 	}
 	err := scenario.Init(testerConfig)

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -83,11 +83,15 @@ func (tester *Tester) Start(seed string) error {
 		}
 
 		// prepare wallets with Eth
-		err = tester.PrepareWallets(seed)
-		if err != nil {
-			return err
+		if tester.config.Scenario != "univ3swaptx" {
+			err = tester.PrepareWallets(seed)
+			if err != nil {
+				return err
+			}
+			go tester.watchWalletBalancesLoop()
+		} else {
+			tester.logger.Infof("univ3tx scenario does not require child wallet funding")
 		}
-		go tester.watchWalletBalancesLoop()
 	}
 
 	return nil


### PR DESCRIPTION
univ3swaptxs scenario has been added to test out the auctioneer system. We do not want any child wallet funding or so. We expect the user to prefund the private key with the necessary Eth and Weth.